### PR TITLE
Added regen buff/armor.

### DIFF
--- a/Assets/Scripts/Game/Defined/Characters/Areas/FieldNPCs.cs
+++ b/Assets/Scripts/Game/Defined/Characters/Areas/FieldNPCs.cs
@@ -25,7 +25,7 @@ namespace Scripts.Game.Defined.Characters {
                 Villager())
                 .AddTalks(new Talk("Test", "<a>Buy some apples."))
                 .AddTalks(new Talk("Shield", "<a>A fine wooden shield, complete with a steel band around the rim."))
-                .AddBuys(new Buy(new Apple()), new Buy(new Shield()));
+                .AddBuys(new Buy(new Apple()), new Buy(new Shield()), new Buy(new RegenerationArmor()));
         }
 
         public static Character Villager() {

--- a/Assets/Scripts/Game/Defined/Serialized/BuffList.cs
+++ b/Assets/Scripts/Game/Defined/Serialized/BuffList.cs
@@ -205,4 +205,20 @@ namespace Scripts.Game.Defined.Serialized.Buffs {
                 );
         }
     }
+
+    public class Regeneration : Buff
+    {
+        private const int REGEN_PER_TURN = 1;
+
+        public Regeneration() : base(Util.GetSprite("health-normal"), "Regeneration", String.Format("Restores {0} health each turn.", REGEN_PER_TURN), false)
+        {
+        }
+
+        protected override IList<SpellEffect> OnEndOfTurnHelper(Model.Characters.Stats owner)
+        {
+            return new SpellEffect[] {
+                new AddToModStat(owner, StatType.HEALTH, REGEN_PER_TURN)
+            };
+        }
+    }
 }

--- a/Assets/Scripts/Game/Defined/Serialized/Items/Equippable.cs
+++ b/Assets/Scripts/Game/Defined/Serialized/Items/Equippable.cs
@@ -45,4 +45,19 @@ namespace Scripts.Game.Defined.Serialized.Items {
             return new DamageResist();
         }
     }
+
+    public class RegenerationArmor : EquippableItem
+    {
+
+        public RegenerationArmor() : base(EquipType.ARMOR, 10, "Regeneration Armor", "Soothing armor that heals wounds.")
+        {
+            Stats.Add(StatType.AGILITY, -2);
+            Stats.Add(StatType.VITALITY, 5);
+        }
+
+        public override Buff CreateBuff()
+        {
+            return new Regeneration();
+        }
+    }
 }


### PR DESCRIPTION
Adds regen buff, essentially the inverse of poison buff.
Removing armor does not remove the associated buff at the moment.
Furthermore, re-equipping the armor reapplies the buff as a stacking buff.
Regeneration armor numbers haven't been balanced.